### PR TITLE
feat: shift tagging responsibility onto Travis CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,7 +70,7 @@ By default, your new animation will be `active` and added to the config file at 
 ```
 Feel free to change this file if you wish to apply a different class name or switch animations on or off 👍
 
-Once you're ready to open a PR for your new animation, be sure to publish the CSS first with `yarn run publish-css`.
+Once you're ready to open a PR with your new animation, be sure to bump the version number in `package.json`. A patch bump is fine 👍
 
 Open a PR following the PR template. Your commit message needn't be complex;
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@ Fixes # || Adds new feature X || Adds whirl <WHIRL NAME>
 ### Checks
 - [ ] Passes linting
 - [ ] Consistent look across browsers
+- [ ] Bumped version in `package.json`

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ install:
   - yarn
 script:
   - yarn test
-before_deploy: yarn publish-css
+before_deploy:
+  - yarn publish-css
+  - git tag -a $TRAVIS_TAG -m 'whirl $TRAVIS_TAG'
 deploy:
   provider: pages
   target-branch: $TRAVIS_TAG

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jh3y/whirl",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "CSS loading animations with minimal effort",
   "author": "jh3y <jhey.dev>",
   "license": "MIT",


### PR DESCRIPTION
<!-- Give your PR an appropriate title linking to any relevant issues -->
Fixes #26 to an extent by shifting the tagging responsibility onto Travis
<!-- What changes are included in this PR -->
### Changes
- `git tag` should be automated by Travis
