### PR TITLE
fix: infinity-path whirl on iOS

### DIFF
--- a/src/whirls/infinity-path.scss
+++ b/src/whirls/infinity-path.scss
@@ -71,7 +71,7 @@
 
 @keyframes infinity-spin {
   from {
-    transform: translate(calc(var(--translate) * 1%), 0) translate(calc(var(--translate-2) * 1px), 0);
+    transform: translate(calc(var(--translate) * 1%), 0) translate(calc(var(--translate-2) * 1px), 0) rotate(0deg);
   }
   to {
     transform: translate(calc(var(--translate) * 1%), 0) translate(calc(var(--translate-2) * 1px), 0) rotate(360deg);


### PR DESCRIPTION
<!-- Give your PR an appropriate title linking to any relevant issues -->
Fixes infinity-path whirl 👍 

### Changes
- add missing `rotate` to start of keyframe 
### Checks
- [x] Passes linting
- [x] Consistent look across browsers